### PR TITLE
Impl protowhat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,13 @@ install:
 - pip install -r requirements.txt
 - pip install .
 script: py.test
+deploy:
+  provider: pypi
+  user: machow
+  password:
+    secure: QTs8hWRaeCo6ZimW6tAPHqH4KVli+5DgXnLQkifv61hMC0rKtag0X6AiHHcXsLJk4TW61TLP5Hzuewzhzkx3VGQdJPSawlWxfJEGciUbcPxG33xSskytZxgp/k6bqE7e+XNR0zskCJRBdTedBiu+mY2jO0gTPm/f6AweZ9wURbR+rb1w4cyiUa2NzzJeehYl1BhJ609Fd1ailmWApyXlh9tzOcbimwChWtD48oZ2RVssiyrAyXsygTak+CmzabFmbufnb+apPek76ikwiGwESOajaWyRL25RCMj+H+64oeMOcyhtVSMnWlzhCyLLuvdwQwbMktUmoEAefTqWKa179hDindYGsOFfBrjXSiHE3s9uozBSmwDXKAcJ62dYP4xN6YT0usC+ZpAe8Jiw2ZlkUi55JYcQcwnurwjBJJgMxXVMgI4c3Eei6tsJhKIRTZ1ZOT+sTXtMF75QvZ+X6+HXrG7SaXn5oAVP2kuNCycpgKDzSZPuHARvWulARsfspJRK0e9urN5G6E/efvLWWpNJ1aYi+K4f70NdiAkgTIzYdQSV2c7FG+pHYSByUK+ArafMwGmCI658YQPgDRMjTrh4h/rxkMPX2196sBNmdea+TaxpNPMHjc3ummgayWz2KIkbqqUb1CYSS/naZJICd/FD2e8nkmAoSU8p2+suNJgqI3c=
+  on:
+    tags: true
+    distributions: sdist bdist_wheel
+    repo: datacamp/shellwhat
+    skip_upload_docs: true

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = shellwhat/tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
+twine
+wheel
 pexpect

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
 	name='shellwhat',
 	version=version,
 	packages=['shellwhat'],
-	install_requires=['protowhat', 'sqlwhat'],
+	install_requires=['protowhat'],
         description = 'Submission correctness tests for shell languages',
         author = 'Michael Chow',
         author_email = 'michael@datacamp.com',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
 	name='shellwhat',
 	version=version,
 	packages=['shellwhat'],
-	install_requires=['sqlwhat'],
+	install_requires=['protowhat', 'sqlwhat'],
         description = 'Submission correctness tests for shell languages',
         author = 'Michael Chow',
         author_email = 'michael@datacamp.com',

--- a/shellwhat/State.py
+++ b/shellwhat/State.py
@@ -5,8 +5,5 @@ class State(BaseState):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # just in case the code is valid postgresql, set as if couldn't parse.
-        # self.solution_ast = self.student_ast = self.ast_dispatcher.ast.AntlrException('', '')
-
     def get_dispatcher(self):
         return None

--- a/shellwhat/State.py
+++ b/shellwhat/State.py
@@ -1,4 +1,4 @@
-from sqlwhat.State import State as BaseState
+from protowhat.State import State as BaseState
 
 class State(BaseState):
 
@@ -6,7 +6,7 @@ class State(BaseState):
         super().__init__(*args, **kwargs)
 
         # just in case the code is valid postgresql, set as if couldn't parse.
-        self.solution_ast = self.student_ast = self.ast_dispatcher.ast.AntlrException('', '')
+        # self.solution_ast = self.student_ast = self.ast_dispatcher.ast.AntlrException('', '')
 
-    def get_dialect(self):
-        return 'postgresql'
+    def get_dispatcher(self):
+        return None

--- a/shellwhat/checks.py
+++ b/shellwhat/checks.py
@@ -1,6 +1,6 @@
 import re
 from functools import partial
-from sqlwhat.checks import test_correct, multi, test_or
+from protowhat.checks.check_logic import *
 
 def test_student_typed(state, text, msg="Submission does not contain the code `{}`.", fixed=False):
     """Test whether the student code contains text.

--- a/shellwhat/checks.py
+++ b/shellwhat/checks.py
@@ -84,7 +84,7 @@ def test_expr(state, expr,
 
     if (strict and res != stu_output) or (res not in stu_output):
         _msg = msg.format(expr, output)
-        state.do_test(msg)
+        state.do_test(_msg)
 
     return state
 

--- a/shellwhat/checks.py
+++ b/shellwhat/checks.py
@@ -1,5 +1,49 @@
 import re
 from functools import partial
+from sqlwhat.checks import test_correct, multi, test_or
+
+def test_student_typed(state, text, msg="Submission does not contain the code `{}`.", fixed=False):
+    """Test whether the student code contains text.
+
+    Args:
+        state: State instance describing student and solution code. Can be omitted if used with Ex().
+        text : text that student code must contain.
+        msg  : feedback message if text is not in student code.
+        fixed: whether to match text exactly, rather than using regular expressions.
+
+    :Example:
+        If the student code is.. ::
+
+            SELECT a FROM b WHERE id < 100
+
+        Then the first test below would (unfortunately) pass, but the second would fail..::
+
+            # contained in student code
+            Ex().test_student_typed(text="id < 10")
+
+            # the $ means that you are matching the end of a line
+            Ex().test_student_typed(text="id < 10$")
+
+        By setting ``fixed = True``, you can search for fixed strings::
+
+            # without fixed = True, '*' matches any character
+            Ex().test_student_typed(text="SELECT * FROM b")               # passes
+            Ex().test_student_typed(text="SELECT \\\\* FROM b")             # fails
+            Ex().test_student_typed(text="SELECT * FROM b", fixed=True)   # fails
+
+    """
+    stu_ast = state.student_ast
+    stu_code = state.student_code
+
+    _msg = msg.format(text)
+
+    # either simple text matching or regex test
+    res = text in stu_code if fixed else re.search(text, stu_code)
+
+    if not res:
+        state.do_test(_msg)
+
+    return state
 
 def test_output_contains(state, text, msg = "Submission does not contain the code `{}`.", fixed = False):
     stu_output = state.student_result

--- a/shellwhat/sct_syntax.py
+++ b/shellwhat/sct_syntax.py
@@ -1,14 +1,12 @@
-from sqlwhat.sct_syntax import SCT_CTX, ATTR_SCTS, state_dec
-import sqlwhat
-
 from shellwhat.State import State
+from shellwhat import checks
+import builtins
 
-# Since the sct_syntax module imports sqlwhat's State, and uses it in functions
-# like state_dec, we need to replace that reference to State w/ shellwhat's version
-# this means that we can use all the SCTs in sqlwhat, with the state from shellwhat
-# TODO: generalize sqlwhat.sct_syntax for protowhat
-sqlwhat.sct_syntax.State = State
+from protowhat.sct_syntax import create_sct_context
 
-from shellwhat.checks import test_output_contains
-ATTR_SCTS['test_output_contains'] = test_output_contains
-SCT_CTX['test_output_contains'] = state_dec(test_output_contains)
+sct_dict = {k: v for k,v in vars(checks).items() if k not in builtins.__dict__ if not k.startswith('__')}
+SCT_CTX = create_sct_context(State, sct_dict)
+
+# put on module for easy importing
+globals().update(SCT_CTX)
+__all__ = list(SCT_CTX.keys())

--- a/shellwhat/test_exercise.py
+++ b/shellwhat/test_exercise.py
@@ -1,5 +1,5 @@
-from sqlwhat.Test import TestFail
-from sqlwhat.Reporter import Reporter
+from protowhat.Test import TestFail
+from protowhat.Reporter import Reporter
 
 from shellwhat.sct_syntax import SCT_CTX
 from shellwhat.State import State
@@ -30,7 +30,7 @@ def test_exercise(sct,
         solution_result = solution_result,
         reporter = Reporter(error))
 
-    State.root_state = state
+    SCT_CTX['Ex'].root_state = state
 
     try:
         exec(sct, SCT_CTX)

--- a/shellwhat/tests/test_checks.py
+++ b/shellwhat/tests/test_checks.py
@@ -37,7 +37,8 @@ def test_expr_error_fail(state):
         checks.test_expr_error(state, "ls filethatdoesnotexist.txt")
 
 def test_expr_error_code1(state):
-    checks.test_expr_error(state, "ls filethatdoesnotexist.txt", output = "1")
+    # cat is used here since BSD and GNU ls use different exit_codes
+    checks.test_expr_error(state, "cat filethatdoesnotexist.txt", output = "1")
 
 def test_expr_error_code1_fail(state):
     with pytest.raises(TF):

--- a/shellwhat/tests/test_checks.py
+++ b/shellwhat/tests/test_checks.py
@@ -10,7 +10,7 @@ import pytest
 
 @pytest.fixture
 def state():
-    return State(student_code = "", solution_code = "",
+    return State(student_code = "some code", solution_code = "some code",
                  pre_exercise_code = "",
                  student_conn = replwrap.bash(),
                  solution_conn = None,
@@ -42,3 +42,12 @@ def test_expr_error_code1(state):
 def test_expr_error_code1_fail(state):
     with pytest.raises(TF):
         checks.test_expr_error(state, "ls", output = "1")
+
+# ensure protowhat SCTs work --------------------------------------------------
+
+def test_multi(state):
+    checks.multi(state, lambda s: checks.test_student_typed(s, "some code"))
+
+def test_multi_fail(state):
+    with pytest.raises(TF):
+        checks.multi(state, lambda s: checks.test_student_typed(s, "some code abc"))

--- a/shellwhat/tests/test_checks.py
+++ b/shellwhat/tests/test_checks.py
@@ -1,8 +1,8 @@
 from shellwhat.test_exercise import test_exercise as te
 from shellwhat.State import State
 from shellwhat import checks
-from sqlwhat.Reporter import Reporter
-from sqlwhat.Test import TestFail as TF
+from protowhat.Reporter import Reporter
+from protowhat.Test import TestFail as TF
 from functools import partial
 from pexpect import replwrap
 


### PR DESCRIPTION
removes sqlwhat from shellwhat 4ever (see https://github.com/datacamp/protowhat/pull/1 first). Will re-run CI once that's deployed