### PR TITLE
Feature ast

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
+sudo: required
 language: python
 python:
 - '3.5'
 install:
 - pip install -r requirements.txt
 - pip install .
-script: py.test
+- "sudo apt-get install -y python python-dev python-pip"
+- "sudo mkdir -p /usr/bin/python2_7 && sudo ln /usr/bin/python2.7 /usr/bin/python2_7/python"
+- 'git clone -b dev-comms https://github.com/datacamp/oil.git && PATH="/usr/bin/python2_7:$PATH" pip2 install -e oil/.'
+script: py.test shellwhat/tests
 deploy:
   provider: pypi
   user: machow

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
 RUN echo hey && git clone -b dev-comms https://github.com/datacamp/oil.git \
     && cd oil && pip2 install -e .
 
-RUN pip3 install git+https://github.com/datacamp/protowhat.git@feature-selectors
+RUN pip3 install protowhat
 
 ADD . shellwhat
 RUN cd shellwhat && pip3 install -r requirements.txt && pip3 install -e . && rm -rf shellwhat/tests/__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:16.04
+
+RUN apt-get update \
+    && apt-get install -y wget curl sudo git libcurl4-openssl-dev ca-certificates build-essential python3 python3-pip \
+    && apt-get install -y python python-dev python-pip \
+    && pip3 install --upgrade pip \
+    && useradd -m repl \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN echo hey && git clone -b dev-comms https://github.com/datacamp/oil.git \
+    && cd oil && pip2 install -e .
+
+RUN pip3 install git+https://github.com/datacamp/protowhat.git@feature-selectors
+
+ADD . shellwhat
+RUN cd shellwhat && pip3 install -r requirements.txt && pip3 install -e . && rm -rf shellwhat/tests/__pycache__
+
+WORKDIR /shellwhat
+
+CMD ["/bin/bash", "-c", "py.test"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pytest
 twine
 wheel
 pexpect

--- a/shellwhat/State.py
+++ b/shellwhat/State.py
@@ -1,4 +1,20 @@
+from protowhat.selectors import Dispatcher
 from protowhat.State import State as BaseState
+
+from protowhat.utils_ast import AstModule
+
+
+from subprocess import check_output
+import shlex
+import json
+
+#PARSER_OSH_STUB = ["python2", "-m", "osh"]
+PARSER_OSH_STUB = ["docker", "exec", "oilc", "python2", "-m", "osh"]
+
+def parse_osh(cmd):
+    sanitized_cmd = shlex.quote(cmd)
+    res = check_output(PARSER_OSH_STUB + [sanitized_cmd])
+    return json.loads(res.decode())
 
 class State(BaseState):
 
@@ -6,4 +22,4 @@ class State(BaseState):
         super().__init__(*args, **kwargs)
 
     def get_dispatcher(self):
-        return None
+        return AstModule.from_parse_dict(parse_osh)

--- a/shellwhat/State.py
+++ b/shellwhat/State.py
@@ -8,12 +8,11 @@ from subprocess import check_output
 import shlex
 import json
 
-#PARSER_OSH_STUB = ["python2", "-m", "osh"]
-PARSER_OSH_STUB = ["docker", "exec", "oilc", "python2", "-m", "osh"]
+PARSER_OSH_STUB = ["python2", "-m", "osh"]
+#PARSER_OSH_STUB = ["docker", "exec", "oilc", "python2", "-m", "osh"]
 
-def parse_osh(cmd):
-    sanitized_cmd = shlex.quote(cmd)
-    res = check_output(PARSER_OSH_STUB + [sanitized_cmd])
+def parse_osh(cmd, strict = False):
+    res = check_output(PARSER_OSH_STUB + [cmd])
     return json.loads(res.decode())
 
 class State(BaseState):
@@ -22,4 +21,6 @@ class State(BaseState):
         super().__init__(*args, **kwargs)
 
     def get_dispatcher(self):
-        return AstModule.from_parse_dict(parse_osh)
+        ast_mod = AstModule.from_parse_dict(parse_osh)
+        return Dispatcher(ast_mod.classes, ast_mod)
+        

--- a/shellwhat/checks.py
+++ b/shellwhat/checks.py
@@ -2,6 +2,7 @@ import re
 from functools import partial, wraps
 from protowhat.checks.check_logic import *
 from protowhat.checks.check_simple import *
+from protowhat.checks.check_funcs import *
 
 ANSI_REGEX = "(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]"
 
@@ -14,6 +15,9 @@ def strip_ansi(state):
 
     return state.to_child(student_result = stu_res)
 
+# TODO: Note that test_student_typed exists in protowhat, but is overwritten below.
+#       This is because it uses ast_node._get_text(), which is not implemented in the
+#       adaptation of the OSH parser yet (but it could be).
 def test_student_typed(state, text, msg="Submission does not contain the code `{}`.", fixed=False):
     """Test whether the student code contains text.
 

--- a/shellwhat/tests/test_selectors.py
+++ b/shellwhat/tests/test_selectors.py
@@ -1,0 +1,52 @@
+from shellwhat.State import State
+from protowhat.Reporter import Reporter
+from protowhat.Test import TestFail as TF
+from protowhat.checks.check_funcs import check_node, check_field, has_equal_ast
+
+import pytest
+from functools import reduce
+
+def reduce_path(path):
+    return reduce(lambda x, y: y(x))
+
+@pytest.fixture('function')
+def state():
+    return State(student_code = "echo a $b ${c}",
+                 solution_code = "echo a $b ${c} unique",
+                 pre_exercise_code = "",
+                 student_conn = None,
+                 solution_conn = None,
+                 student_result = "",
+                 solution_result = "",
+                 reporter = Reporter()
+                 )
+
+def test_osh_selector_result(state):
+    target = state.ast_dispatcher.nodes.get('CompoundWord')
+    cl = check_node(state, "SimpleCommand")
+    cmd = check_field(cl, 'words', 0)
+    assert isinstance(cmd.student_ast, target)
+    assert cmd.student_ast.parts[0].token == "echo"
+
+def test_osh_selector_var_sub(state):
+    target = state.ast_dispatcher.nodes.get('SimpleVarSub')
+    cl = check_node(state, "SimpleCommand")
+    word = check_field(cl, 'words', 2)
+    varsub = check_field(word, 'parts', 0)
+
+    assert isinstance(varsub.student_ast, target)
+    assert varsub.student_ast.token == "$b"
+
+def test_osh_selector_high_priority(state):
+    target = state.ast_dispatcher.nodes.get('BracedVarSub')
+    child = check_node(state, 'BracedVarSub', priority = 99)
+    assert isinstance(child.student_ast, target)
+    assert child.student_ast.token == 'c'
+
+def test_osh_selector_fail(state):
+    child = check_node(state, 'SimpleCommand')
+    with pytest.raises(TF):
+        check_field(child, 'words', 4)
+
+def test_has_equal_ast_simple(state):
+    pass


### PR DESCRIPTION
Note that

1. the osh parser being used is from this branch: https://github.com/datacamp/oil/tree/dev-comms
2. I couldn't get the osh parser running on mac, so did all testing inside docker (and will update travis, the README.md, and fix all kinds of docs) once protowhat is merged.

There are still some things I would change about the osh AST. For example the tree below shows a Sentence node, because the statement ended with `;`, but we likely want to remove all Sentence nodes...

![image](https://user-images.githubusercontent.com/2574498/29587292-872db240-875b-11e7-98e4-8d1ae5da5881.png)
