### PR TITLE
parser fails gracefully, more unit tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,6 @@ RUN apt-get update \
 RUN echo hey && git clone -b dev-comms https://github.com/datacamp/oil.git \
     && cd oil && pip2 install -e .
 
-RUN pip3 install protowhat
-
 ADD . shellwhat
 RUN cd shellwhat && pip3 install -r requirements.txt && pip3 install -e .
 

--- a/shellwhat/State.py
+++ b/shellwhat/State.py
@@ -1,6 +1,6 @@
 from protowhat.selectors import Dispatcher
 from protowhat.State import State as BaseState
-from shellwhat.parsers import OshParser
+from shellwhat.parsers import OshParser, ParseError
 
 class State(BaseState):
 
@@ -9,6 +9,6 @@ class State(BaseState):
 
     @staticmethod
     def get_dispatcher():
-        ast_mod = OshParser()
+        ast_mod = OshParser(ParseError = ParseError)
         return Dispatcher(ast_mod.classes, ast_mod)
         

--- a/shellwhat/parsers.py
+++ b/shellwhat/parsers.py
@@ -6,10 +6,14 @@ import json
 #PARSER_OSH_STUB = ["docker", "exec", "oilc", "python2", "-m", "osh"]
 PARSER_OSH_STUB = ["python2", "-m", "osh"]
 
+class ParseError(Exception): pass
+
 class OshParser(AstModule):
     def parse(self, code, strict = True):
         res = check_output(PARSER_OSH_STUB + [code])
         ast_dict = json.loads(res.decode())
+        if ast_dict is None:
+            raise self.ParseError("Parser returned None")
         tree = self.load(ast_dict)
         return OshTransformer().visit(tree)
 


### PR DESCRIPTION
Now it correctly raises a ParseError when osh parses code with syntax error