### PR TITLE
update mocks to fix docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,10 @@ import sys
 from unittest import mock
  
 MOCK_MODULES = ['protowhat', 'protowhat.checks',
-                'protowhat.checks.check_logic', 'protowhat.checks.check_simple', 'protowhat.checks.check_funcs']
+                'protowhat.checks.check_logic',
+                'protowhat.checks.check_simple',
+                'protowhat.checks.check_funcs',
+                'protowhat.checks.check_files']
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = mock.Mock()
 


### PR DESCRIPTION
@gvwilson just a note, readthedocs (where shellwhat docs are hosted) doesn't need to have any package dependencies installed. Rather, packages are mocked in the sphinx config. The docs in this case were failing to build because I had shellwhat start using a new set of SCTs from protowhat (`protowhat.checks.check_files`), but didn't mock that module for the shellwhat docs.

(all of this is to say that, and you are going to love this, the way sphinx autodocuments requires running the code being documented ;)