### PR TITLE
Add `force_diagnose` parameter to `test_exercise`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # pkg deps
-protowhat==1.1.1
+protowhat==1.2.0
 pexpect==4.6.0
 
 # test deps

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # pkg deps
-protowhat==1.2.0
+protowhat==1.3.0
 pexpect==4.6.0
 
 # test deps

--- a/shellwhat/test_exercise.py
+++ b/shellwhat/test_exercise.py
@@ -14,6 +14,7 @@ def test_exercise(sct,
                   pre_exercise_code,
                   ex_type,
                   error,
+                  force_diagnose = False,
                   debug = False   # currently unused
                   ):
     """
@@ -27,7 +28,8 @@ def test_exercise(sct,
         solution_conn = solution_conn,
         student_result = student_result,
         solution_result = solution_result,
-        reporter = Reporter(error))
+        reporter = Reporter(error),
+        force_diagnose = force_diagnose)
 
     SCT_CTX['Ex'].root_state = state
 


### PR DESCRIPTION
Support datacamp/exercise-validator/issues/158 by accepting the `force_diagnose` parameter.

This PR depends on protowhat release for `check_correct` implementation (datacamp/protowhat/pull/28).